### PR TITLE
fixing swift target and wiping away divide-by-zero defects

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ With the Docker images now pushed to a private or public Docker registry, just u
 For example, you'll need to set a `Mayhemfile` with a `baseimage` parameter similar to the following for a private Docker registry, where `$MAYHEM_DOCKER_REGISTRY` represents the URL of the private Mayhem Docker registry:
 
 ```yaml
-version: '1.14'
+version: '1.16'
 baseimage: $MAYHEM_DOCKER_REGISTRY/fuzzme/c-base-executable:latest
 duration: 90
 project: fuzzme
@@ -131,7 +131,7 @@ cmds:
 Otherwise, you can set the `Mayhemfile` with a `baseimage` parameter to a public Docker Hub URL like so:
 
 ```yaml
-version: '1.14'
+version: '1.16'
 baseimage: fuzzme/c-base-executable:latest
 duration: 90
 project: fuzzme

--- a/ada/base-executable/ada-base-executable/README.md
+++ b/ada/base-executable/ada-base-executable/README.md
@@ -12,7 +12,7 @@ docker push $DOCKER_REGISTRY/fuzzme/ada-base-executable
 Then initiate a Mayhem run using a Mayhemfile similar to the following:
 
 ```yaml
-version: '1.14'
+version: '1.16'
 baseimage: $MAYHEM_DOCKER_REGISTRY/fuzzme/ada-base-executable:latest
 project: fuzzme
 target: ada-base-executable

--- a/android/base-executable/android-base-executable/README.md
+++ b/android/base-executable/android-base-executable/README.md
@@ -12,7 +12,7 @@ docker push $DOCKER_REGISTRY/fuzzme/android-base-executable
 Then initiate a Mayhem run using a Mayhemfile similar to the following:
 
 ```yaml
-version: '1.14'
+version: '1.16'
 baseimage: $MAYHEM_DOCKER_REGISTRY/fuzzme/android-base-executable:latest
 duration: 90
 project: fuzzme

--- a/c/afl/c-afl-clang/README.md
+++ b/c/afl/c-afl-clang/README.md
@@ -12,7 +12,7 @@ docker push $DOCKER_REGISTRY/fuzzme/c-afl-clang
 Then initiate a Mayhem run using a Mayhemfile similar to the following:
 
 ```yaml
-version: '1.14'
+version: '1.16'
 baseimage: $MAYHEM_DOCKER_REGISTRY/fuzzme/c-afl-clang:latest
 duration: 90
 project: fuzzme

--- a/c/afl/c-afl-gcc/README.md
+++ b/c/afl/c-afl-gcc/README.md
@@ -12,7 +12,7 @@ docker push $DOCKER_REGISTRY/fuzzme/c-afl-gcc
 Then initiate a Mayhem run using a Mayhemfile similar to the following:
 
 ```yaml
-version: '1.14'
+version: '1.16'
 baseimage: $MAYHEM_DOCKER_REGISTRY/fuzzme/c-afl-gcc:latest
 duration: 90
 project: fuzzme

--- a/c/aflpp/c-aflpp-clang/README.md
+++ b/c/aflpp/c-aflpp-clang/README.md
@@ -12,7 +12,7 @@ docker push $DOCKER_REGISTRY/fuzzme/c-aflpp-clang
 Then initiate a Mayhem run using a Mayhemfile similar to the following:
 
 ```yaml
-version: '1.14'
+version: '1.16'
 baseimage: $MAYHEM_DOCKER_REGISTRY/fuzzme/c-aflpp-clang:latest
 duration: 90
 project: fuzzme

--- a/c/aflpp/c-aflpp-gcc/README.md
+++ b/c/aflpp/c-aflpp-gcc/README.md
@@ -12,7 +12,7 @@ docker push $DOCKER_REGISTRY/fuzzme/c-aflpp-gcc
 Then initiate a Mayhem run using a Mayhemfile similar to the following:
 
 ```yaml
-version: '1.14'
+version: '1.16'
 baseimage: $MAYHEM_DOCKER_REGISTRY/fuzzme/c-aflpp-gcc:latest
 duration: 90
 project: fuzzme

--- a/c/base-executable/c-base-executable/README.md
+++ b/c/base-executable/c-base-executable/README.md
@@ -12,7 +12,7 @@ docker push $DOCKER_REGISTRY/fuzzme/c-base-executable
 Then initiate a Mayhem run using a Mayhemfile similar to the following:
 
 ```yaml
-version: '1.14'
+version: '1.16'
 baseimage: $MAYHEM_DOCKER_REGISTRY/fuzzme/c-base-executable:latest
 duration: 90
 project: fuzzme

--- a/c/base-executable/powerpc-c-base-executable/README.md
+++ b/c/base-executable/powerpc-c-base-executable/README.md
@@ -12,7 +12,7 @@ docker push $DOCKER_REGISTRY/fuzzme/powerpc-c-base-executable
 Then initiate a Mayhem run using a Mayhemfile similar to the following:
 
 ```yaml
-version: '1.14'
+version: '1.16'
 baseimage: $MAYHEM_DOCKER_REGISTRY/fuzzme/powerpc-c-base-executable:latest
 duration: 120
 project: fuzzme

--- a/c/base-executable/powerpc64-c-base-executable/README.md
+++ b/c/base-executable/powerpc64-c-base-executable/README.md
@@ -12,7 +12,7 @@ docker push $DOCKER_REGISTRY/fuzzme/powerpc64-c-base-executable
 Then initiate a Mayhem run using a Mayhemfile similar to the following:
 
 ```yaml
-version: '1.14'
+version: '1.16'
 baseimage: $MAYHEM_DOCKER_REGISTRY/fuzzme/powerpc64-c-base-executable:latest
 duration: 120
 project: fuzzme

--- a/c/base-executable/powerpc64le-c-base-executable/README.md
+++ b/c/base-executable/powerpc64le-c-base-executable/README.md
@@ -12,7 +12,7 @@ docker push $DOCKER_REGISTRY/fuzzme/powerpc64le-c-base-executable
 Then initiate a Mayhem run using a Mayhemfile similar to the following:
 
 ```yaml
-version: '1.14'
+version: '1.16'
 baseimage: $MAYHEM_DOCKER_REGISTRY/fuzzme/powerpc64le-c-base-executable:latest
 duration: 120
 project: fuzzme

--- a/c/honggfuzz/c-honggfuzz-clang/README.md
+++ b/c/honggfuzz/c-honggfuzz-clang/README.md
@@ -12,7 +12,7 @@ docker push $DOCKER_REGISTRY/fuzzme/c-honggfuzz-clang
 Then initiate a Mayhem run using a Mayhemfile similar to the following:
 
 ```yaml
-version: '1.14'
+version: '1.16'
 baseimage: $MAYHEM_DOCKER_REGISTRY/fuzzme/c-honggfuzz-clang:latest
 duration: 90
 project: fuzzme

--- a/c/honggfuzz/c-honggfuzz-gcc/README.md
+++ b/c/honggfuzz/c-honggfuzz-gcc/README.md
@@ -12,7 +12,7 @@ docker push $DOCKER_REGISTRY/fuzzme/c-honggfuzz-gcc
 Then initiate a Mayhem run using a Mayhemfile similar to the following:
 
 ```yaml
-version: '1.14'
+version: '1.16'
 baseimage: $MAYHEM_DOCKER_REGISTRY/fuzzme/c-honggfuzz-gcc:latest
 duration: 90
 project: fuzzme

--- a/c/libfuzzer/c-libfuzzer/README.md
+++ b/c/libfuzzer/c-libfuzzer/README.md
@@ -12,7 +12,7 @@ docker push $DOCKER_REGISTRY/fuzzme/c-libfuzzer
 Then initiate a Mayhem run using a Mayhemfile similar to the following:
 
 ```yaml
-version: '1.14'
+version: '1.16'
 baseimage: $MAYHEM_DOCKER_REGISTRY/fuzzme/c-libfuzzer:latest
 duration: 90
 project: fuzzme

--- a/cpp/afl/cpp-afl-clang/README.md
+++ b/cpp/afl/cpp-afl-clang/README.md
@@ -12,7 +12,7 @@ docker push $DOCKER_REGISTRY/fuzzme/cpp-afl-clang
 Then initiate a Mayhem run using a Mayhemfile similar to the following:
 
 ```yaml
-version: '1.14'
+version: '1.16'
 baseimage: $MAYHEM_DOCKER_REGISTRY/fuzzme/cpp-afl-clang:latest
 duration: 90
 project: fuzzme

--- a/cpp/afl/cpp-afl-gcc/README.md
+++ b/cpp/afl/cpp-afl-gcc/README.md
@@ -12,7 +12,7 @@ docker push $DOCKER_REGISTRY/fuzzme/cpp-afl-gcc
 Then initiate a Mayhem run using a Mayhemfile similar to the following:
 
 ```yaml
-version: '1.14'
+version: '1.16'
 baseimage: $MAYHEM_DOCKER_REGISTRY/fuzzme/cpp/cpp-afl-gcc:latest
 duration: 90
 project: cpp

--- a/cpp/aflpp/cpp-aflpp-clang/README.md
+++ b/cpp/aflpp/cpp-aflpp-clang/README.md
@@ -12,7 +12,7 @@ docker push $DOCKER_REGISTRY/fuzzme/cpp-aflpp-clang
 Then initiate a Mayhem run using a Mayhemfile similar to the following:
 
 ```yaml
-version: '1.14'
+version: '1.16'
 baseimage: $MAYHEM_DOCKER_REGISTRY/fuzzme/cpp-aflpp-clang:latest
 duration: 90
 project: fuzzme

--- a/cpp/aflpp/cpp-aflpp-gcc/README.md
+++ b/cpp/aflpp/cpp-aflpp-gcc/README.md
@@ -12,7 +12,7 @@ docker push $DOCKER_REGISTRY/fuzzme/cpp-aflpp-gcc
 Then initiate a Mayhem run using a Mayhemfile similar to the following:
 
 ```yaml
-version: '1.14'
+version: '1.16'
 baseimage: $MAYHEM_DOCKER_REGISTRY/fuzzme/cpp-aflpp-gcc:latest
 duration: 90
 project: fuzzme

--- a/cpp/base-executable/cpp-base-executable/README.md
+++ b/cpp/base-executable/cpp-base-executable/README.md
@@ -12,7 +12,7 @@ docker push $DOCKER_REGISTRY/fuzzme/cpp-base-executable
 Then initiate a Mayhem run using a Mayhemfile similar to the following:
 
 ```yaml
-version: '1.14'
+version: '1.16'
 baseimage: $MAYHEM_DOCKER_REGISTRY/fuzzme/cpp-base-executable:latest
 duration: 90
 project: fuzzme

--- a/cpp/honggfuzz/cpp-honggfuzz-clang/README.md
+++ b/cpp/honggfuzz/cpp-honggfuzz-clang/README.md
@@ -12,7 +12,7 @@ docker push $DOCKER_REGISTRY/fuzzme/cpp-honggfuzz-clang
 Then initiate a Mayhem run using a Mayhemfile similar to the following:
 
 ```yaml
-version: '1.14'
+version: '1.16'
 baseimage: $MAYHEM_DOCKER_REGISTRY/fuzzme/cpp-honggfuzz-clang:latest
 duration: 90
 project: fuzzme

--- a/cpp/honggfuzz/cpp-honggfuzz-gcc/README.md
+++ b/cpp/honggfuzz/cpp-honggfuzz-gcc/README.md
@@ -12,7 +12,7 @@ docker push $DOCKER_REGISTRY/fuzzme/cpp-honggfuzz-gcc
 Then initiate a Mayhem run using a Mayhemfile similar to the following:
 
 ```yaml
-version: '1.14'
+version: '1.16'
 baseimage: $MAYHEM_DOCKER_REGISTRY/fuzzme/cpp-honggfuzz-gcc:latest
 duration: 90
 project: fuzzme

--- a/cpp/libfuzzer/cpp-libfuzzer/README.md
+++ b/cpp/libfuzzer/cpp-libfuzzer/README.md
@@ -12,7 +12,7 @@ docker push $DOCKER_REGISTRY/fuzzme/cpp-libfuzzer
 Then initiate a Mayhem run using a Mayhemfile similar to the following:
 
 ```yaml
-version: '1.14'
+version: '1.16'
 baseimage: $MAYHEM_DOCKER_REGISTRY/fuzzme/cpp-libfuzzer:latest
 duration: 90
 project: fuzzme

--- a/fortran/base-executable/fortran-base-executable/README.md
+++ b/fortran/base-executable/fortran-base-executable/README.md
@@ -12,7 +12,7 @@ docker push $DOCKER_REGISTRY/fuzzme/fortran-base-executable
 Then initiate a Mayhem run using a Mayhemfile similar to the following:
 
 ```yaml
-version: '1.14'
+version: '1.16'
 baseimage: fuzzme/fortran-base-executable:latest
 duration: 90
 project: fuzzme

--- a/go/base-executable/go-base-executable/README.md
+++ b/go/base-executable/go-base-executable/README.md
@@ -12,7 +12,7 @@ docker push $DOCKER_REGISTRY/fuzzme/go-base-executable
 Then initiate a Mayhem run using a Mayhemfile similar to the following:
 
 ```yaml
-version: '1.14'
+version: '1.16'
 baseimage: $MAYHEM_DOCKER_REGISTRY/fuzzme/go-base-executable:latest
 duration: 90
 project: fuzzme

--- a/go/libfuzzer/go-go-fuzz/README.md
+++ b/go/libfuzzer/go-go-fuzz/README.md
@@ -12,7 +12,7 @@ docker push $DOCKER_REGISTRY/fuzzme/go-go-fuzz
 Then initiate a Mayhem run using a Mayhemfile similar to the following:
 
 ```yaml
-version: '1.14'
+version: '1.16'
 baseimage: $MAYHEM_DOCKER_REGISTRY/fuzzme/go/go-go-fuzz:latest
 duration: 90
 project: go

--- a/java/base-executable/java-base-executable/README.md
+++ b/java/base-executable/java-base-executable/README.md
@@ -12,7 +12,7 @@ docker push $DOCKER_REGISTRY/fuzzme/java-base-executable
 Then initiate a Mayhem run using a Mayhemfile similar to the following:
 
 ```yaml
-version: '1.14'
+version: '1.16'
 baseimage: $MAYHEM_DOCKER_REGISTRY/fuzzme/java-base-executable:latest
 duration: 120
 project: fuzzme

--- a/java/base-executable/java-base-executable/src/FuzzMe.java
+++ b/java/base-executable/java-base-executable/src/FuzzMe.java
@@ -24,7 +24,7 @@ public class FuzzMe {
             if (input.charAt(0) == 'b') {
                 if (input.charAt(1) == 'u') {
                     if (input.charAt(2) == 'g') {
-                        int i = 1 / 0;
+                        System.exit(-1);
                     }
                 }
             }

--- a/java/base-executable/java-base-executable/src/FuzzMe.java
+++ b/java/base-executable/java-base-executable/src/FuzzMe.java
@@ -24,7 +24,7 @@ public class FuzzMe {
             if (input.charAt(0) == 'b') {
                 if (input.charAt(1) == 'u') {
                     if (input.charAt(2) == 'g') {
-                        System.exit(-1);
+                        throw new RuntimeException("Made it to the bug!");
                     }
                 }
             }

--- a/java/libfuzzer/java-jazzer/README.md
+++ b/java/libfuzzer/java-jazzer/README.md
@@ -12,7 +12,7 @@ docker push $DOCKER_REGISTRY/fuzzme/java-jazzer
 Then initiate a Mayhem run using a Mayhemfile similar to the following:
 
 ```yaml
-version: '1.14'
+version: '1.16'
 baseimage: $MAYHEM_DOCKER_REGISTRY/fuzzme/java-jazzer:latest
 duration: 90
 project: fuzzme

--- a/java/libfuzzer/java-jazzer/src/FuzzMe.java
+++ b/java/libfuzzer/java-jazzer/src/FuzzMe.java
@@ -7,7 +7,7 @@ public class FuzzMe {
             if (input.charAt(0) == 'b') {
                 if (input.charAt(1) == 'u') {
                     if (input.charAt(2) == 'g') {
-                        throw new Exception("Made it to the bug!");
+                        System.exit(-1);
                     }
                 }
             }

--- a/java/libfuzzer/java-jazzer/src/FuzzMe.java
+++ b/java/libfuzzer/java-jazzer/src/FuzzMe.java
@@ -7,7 +7,7 @@ public class FuzzMe {
             if (input.charAt(0) == 'b') {
                 if (input.charAt(1) == 'u') {
                     if (input.charAt(2) == 'g') {
-                        int i = 1 / 0;
+                        throw new Exception("Made it to the bug!");
                     }
                 }
             }

--- a/kotlin/libfuzzer/kotlin-jazzer/README.md
+++ b/kotlin/libfuzzer/kotlin-jazzer/README.md
@@ -12,7 +12,7 @@ docker push $DOCKER_REGISTRY/fuzzme/kotlin-jazzer
 Then initiate a Mayhem run using a Mayhemfile similar to the following:
 
 ```yaml
-version: '1.14'
+version: '1.16'
 baseimage: $MAYHEM_DOCKER_REGISTRY/fuzzme/kotlin-jazzer:latest
 duration: 90
 project: fuzzme

--- a/kotlin/libfuzzer/kotlin-jazzer/src/fuzzme.kt
+++ b/kotlin/libfuzzer/kotlin-jazzer/src/fuzzme.kt
@@ -10,20 +10,9 @@ fun fuzzerTestOneInput(data: ByteArray) {
         if (input.get(0) == 'b') {
             if (input.get(1) == 'u') {
                 if (input.get(2) == 'g') {
-                    val i: Int = 1 / 0;
+                    System.exit(-1);
                 }
             }
         }
     }
 }
-
-// fun fuzzerTestOneInput(data: ByteArray) {
-//     val input = String(data)
-//     if (input.startsWith("b", 0)) {
-//         if (input.startsWith("u", 1)) {
-//             if (input.startsWith("g", 2)) {
-//                 val i: Int = 1 / 0;
-//             }
-//         }
-//     }
-// }

--- a/objective-c/base-executable/obj-c-base-executable/README.md
+++ b/objective-c/base-executable/obj-c-base-executable/README.md
@@ -12,7 +12,7 @@ docker push $DOCKER_REGISTRY/fuzzme/obj-c-base-executable
 Then initiate a Mayhem run using a Mayhemfile similar to the following:
 
 ```yaml
-version: '1.14'
+version: '1.16'
 baseimage: $MAYHEM_DOCKER_REGISTRY/fuzzme/obj-c-base-executable:latest
 duration: 90
 project: fuzzme

--- a/ocaml/afl/ocaml-afl/README.md
+++ b/ocaml/afl/ocaml-afl/README.md
@@ -12,7 +12,7 @@ docker push $DOCKER_REGISTRY/fuzzme/ocaml-afl
 Then initiate a Mayhem run using a Mayhemfile similar to the following:
 
 ```yaml
-version: '1.14'
+version: '1.16'
 baseimage: $MAYHEM_DOCKER_REGISTRY/fuzzme/ocaml-afl:latest
 duration: 90
 project: fuzzme

--- a/ocaml/base-executable/ocaml-base-executable/README.md
+++ b/ocaml/base-executable/ocaml-base-executable/README.md
@@ -12,7 +12,7 @@ docker push $DOCKER_REGISTRY/fuzzme/ocaml-base-executable
 Then initiate a Mayhem run using a Mayhemfile similar to the following:
 
 ```yaml
-version: '1.14'
+version: '1.16'
 baseimage: $MAYHEM_DOCKER_REGISTRY/fuzzme/ocaml-base-executable:latest
 duration: 90
 project: fuzzme

--- a/python/libfuzzer/python-atheris/README.md
+++ b/python/libfuzzer/python-atheris/README.md
@@ -12,7 +12,7 @@ docker push $DOCKER_REGISTRY/fuzzme/python-atheris
 Then initiate a Mayhem run using a Mayhemfile similar to the following:
 
 ```yaml
-version: '1.14'
+version: '1.16'
 baseimage: $MAYHEM_DOCKER_REGISTRY/fuzzme/python/python-atheris:latest
 duration: 90
 project: python

--- a/python/libfuzzer/python-atheris/src/fuzzme.py
+++ b/python/libfuzzer/python-atheris/src/fuzzme.py
@@ -2,14 +2,14 @@
 
 import atheris
 import sys
+import os
 
 def TestOneInput(data):
     if len(data) >= 3 :    
         if data[0] == ord('b'):
             if data[1] == ord('u'):
                 if data[2] == ord('g'):
-                    print("Made it to the bug!")
-                    return 1 / 0
+                    raise Exception("Made it to the bug!")
 
 atheris.Setup(sys.argv, TestOneInput)
 atheris.Fuzz()

--- a/rust/afl/rust-afl/README.md
+++ b/rust/afl/rust-afl/README.md
@@ -12,7 +12,7 @@ docker push $DOCKER_REGISTRY/fuzzme/rust-afl
 Then initiate a Mayhem run using a Mayhemfile similar to the following:
 
 ```yaml
-version: '1.14'
+version: '1.16'
 baseimage: $MAYHEM_DOCKER_REGISTRY/fuzzme/rust/rust-afl:latest
 duration: 90
 project: rust

--- a/rust/base-executable/rust-base-executable/README.md
+++ b/rust/base-executable/rust-base-executable/README.md
@@ -12,7 +12,7 @@ docker push $DOCKER_REGISTRY/fuzzme/rust-base-executable
 Then initiate a Mayhem run using a Mayhemfile similar to the following:
 
 ```yaml
-version: '1.14'
+version: '1.16'
 baseimage: fuzzme/rust-base-executable:latest
 duration: 90
 project: fuzzme

--- a/rust/libfuzzer/rust-cargo-fuzz/README.md
+++ b/rust/libfuzzer/rust-cargo-fuzz/README.md
@@ -12,7 +12,7 @@ docker push $DOCKER_REGISTRY/fuzzme/rust-cargo-fuzz
 Then initiate a Mayhem run using a Mayhemfile similar to the following:
 
 ```yaml
-version: '1.14'
+version: '1.16'
 baseimage: $MAYHEM_DOCKER_REGISTRY/fuzzme/rust-cargo-fuzz:latest
 duration: 90
 project: rust

--- a/swift/libfuzzer/swift-libfuzzer/Dockerfile
+++ b/swift/libfuzzer/swift-libfuzzer/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:groovy
+FROM ubuntu:jammy
 
 # Set non-interactive mode so tzdata doesn't hold up Docker build
 ENV DEBIAN_FRONTEND=noninteractive
@@ -28,7 +28,7 @@ ENV PATH="${PATH}:/swift-5.4.2-RELEASE-ubuntu20.04/usr/bin"
 RUN swiftc -sanitize=fuzzer -parse-as-library fuzzme.swift -o /fuzzme
 
 # Set multi-stage build to optimize space
-FROM ubuntu:groovy
+FROM ubuntu:jammy
 COPY --from=0 /fuzzme .
 COPY --from=0 /swift-5.4.2-RELEASE-ubuntu20.04/usr/lib/swift/linux/libswiftSwiftOnoneSupport.so /swift-5.4.2-RELEASE-ubuntu20.04/usr/lib/swift/linux/libswiftSwiftOnoneSupport.so
 COPY --from=0 /swift-5.4.2-RELEASE-ubuntu20.04/usr/lib/swift/linux/libswiftCore.so /swift-5.4.2-RELEASE-ubuntu20.04/usr/lib/swift/linux/libswiftCore.so

--- a/swift/libfuzzer/swift-libfuzzer/README.md
+++ b/swift/libfuzzer/swift-libfuzzer/README.md
@@ -12,7 +12,7 @@ docker push $DOCKER_REGISTRY/fuzzme/swift-libfuzzer
 Then initiate a Mayhem run using a Mayhemfile similar to the following:
 
 ```yaml
-version: '1.14'
+version: '1.16'
 baseimage: $MAYHEM_DOCKER_REGISTRY/fuzzme/swift-libfuzzer:latest
 duration: 90
 project: fuzzme


### PR DESCRIPTION
This MR removes the remaining divide-by-zero defects for:
1. python-atheris
2. java-base-executbale
3. java-jazzer
4. kotlin-jazzer

Also fixes the swift target by changing the base image from the deprecated `ubuntu:groovy` to `ubuntu:jammy`.